### PR TITLE
Update to aldeed:autoform@6.0.0 and simpl-schema npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Upload and manage files with autoForm via [`ostrio:files`](https://github.com/Ve
 
  - Install `meteor add ostrio:autoform-files`
  - Install `meteor add ostrio:files`, *if not yet installed*
+ - Add this config to `simpl-schema` NPM package (depending of the language that you are using):
+```javascript
+SimpleSchema.setDefaultMessages({
+  initialLanguage: 'en',
+  messages: {
+    en: {
+      uploadError: '{{value}}', //File-upload
+    },
+  }
+});
+```
  - Create your Files Collection (See [`ostrio:files`](https://github.com/VeliovGroup/Meteor-Files))
 ```javascript
 var Images = new FilesCollection({

--- a/lib/client/autoform.js
+++ b/lib/client/autoform.js
@@ -13,7 +13,3 @@ AutoForm._globalHooks.onSuccess.push(function (type) {
     }
   }
 });
-
-SimpleSchema.messages({
-  uploadError: '[value]'
-});

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -68,13 +68,13 @@ Template.afFileUpload.events({
       }, false);
 
       upload.on('start', function () {
-        AutoForm.getValidationContext().resetValidation();
+        AutoForm.getValidationContext().reset();
         template.currentUpload.set(this);
         return;
       });
 
       upload.on('error', function (error) {
-        AutoForm.getValidationContext().resetValidation();
+        AutoForm.getValidationContext().reset();
         AutoForm.getValidationContext().addInvalidKeys([{name: Template.instance().inputName, type: 'uploadError', value: error.reason}]);
         $(e.currentTarget).val('');
         return;

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '2.0.0',
+  version: '2.0.1',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '1.0.12',
+  version: '2.0.0',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 
@@ -14,7 +14,7 @@ Package.onUse(function(api) {
     'underscore',
     'reactive-var',
     'templating',
-    'aldeed:autoform@5.8.1',
+    'aldeed:autoform@6.0.0',
     'ostrio:files@1.7.11'
   ]);
 


### PR DESCRIPTION
Hi,
this is a quick update:
- If I don't make mistake, `SimpleSchema.messages` don't seem to work anymore
- So, SimpleSchema is not called from the package anymore. The error messages must be configured manually.