### PR TITLE
Make use of dburles:mongo-collection-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ var Images = new FilesCollection({
   }
 })
 
+// if you want to make use of dburles:mongo-collection-instances
+// you need to create a 'parent' reference to the underlying collection
+Images.collection.filesCollection = Images;
+
 if (Meteor.isClient) {
   Meteor.subscribe('files.images.all');
 }
@@ -44,7 +48,8 @@ if (Meteor.isServer) {
   });
 }
 ```
-__Note:__ `Images` variable must be attached to *Global* scope. And has same name (*case-sensitive*) as `collectionName` option passed into `FilesCollectio#insert({collectionName: 'Images'})` method, `Images` in our case.
+__Note:__ If you don't use Mongo Collection instances, then the `Images` variable must be attached to *Global* scope. And has same name (*case-sensitive*) as `collectionName` option passed into `FilesCollection#insert({collectionName: 'Images'})` method, `Images` in our case.
+
 
  - Define your schema and set the `autoform` property like in the example below
 ```javascript

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -13,7 +13,7 @@ Template.afFileUpload.onCreated(function () {
   }
   console.log(this.data);
   this.collection      = Mongo.Collection.get
-    ? Mongo.Collection.get(this.data.atts.collection)
+    ? Mongo.Collection.get(this.data.atts.collection).filesCollection
     : Meteor.connection._mongo_livedata_collections[this.data.atts.collection];
   this.uploadTemplate  = this.data.atts.uploadTemplate || null;
   this.previewTemplate = this.data.atts.previewTemplate || null;
@@ -49,7 +49,7 @@ Template.afFileUpload.helpers({
   uploadedFile() {
     var collectionName = Template.instance().collectionName();
     var collection = Mongo.Collection.get
-      ? Mongo.Collection.get(collectionName)
+      ? Mongo.Collection.get(collectionName).filesCollection
       : global[collectionName];
     return collection.findOne({
       _id: Template.instance().fileId.get() || this.value
@@ -75,11 +75,13 @@ Template.afFileUpload.events({
   },
   'change [data-files-collection-upload]'(e, template) {
     if (e.currentTarget.files && e.currentTarget.files[0]) {
+
       var collectionName = template.collectionName();
       var collection = Mongo.Collection.get
         ? Mongo.Collection.get(collectionName)
         : global[template.collectionName()];
-      var upload = collection.insert({
+
+      var upload = collection.filesCollection.insert({
         file: e.currentTarget.files[0],
         streams: 'dynamic',
         chunkSize: 'dynamic'

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -3,6 +3,7 @@ import { Meteor }      from 'meteor/meteor';
 import { AutoForm }    from 'meteor/aldeed:autoform';
 import { Template }    from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
+import { Mongo }       from 'meteor/mongo';
 
 Template.afFileUpload.onCreated(function () {
   if (!this.data) {
@@ -11,7 +12,7 @@ Template.afFileUpload.onCreated(function () {
     };
   }
 
-  this.collection      = Meteor.connection._mongo_livedata_collections[this.data.atts.collection];
+  this.collection      = Mongo.Collection.get(his.data.atts.collection); //Meteor.connection._mongo_livedata_collections[this.data.atts.collection];
   this.uploadTemplate  = this.data.atts.uploadTemplate || null;
   this.previewTemplate = this.data.atts.previewTemplate || null;
 

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -11,8 +11,10 @@ Template.afFileUpload.onCreated(function () {
       atts: {}
     };
   }
-
-  this.collection      = Mongo.Collection.get(his.data.atts.collection); //Meteor.connection._mongo_livedata_collections[this.data.atts.collection];
+  console.log(this.data);
+  this.collection      = Mongo.Collection.get
+    ? Mongo.Collection.get(this.data.atts.collection)
+    : Meteor.connection._mongo_livedata_collections[this.data.atts.collection];
   this.uploadTemplate  = this.data.atts.uploadTemplate || null;
   this.previewTemplate = this.data.atts.previewTemplate || null;
 
@@ -45,7 +47,11 @@ Template.afFileUpload.helpers({
     return Template.instance().fileId.get() || this.value;
   },
   uploadedFile() {
-    return global[Template.instance().collectionName()].findOne({
+    var collectionName = Template.instance().collectionName();
+    var collection = Mongo.Collection.get
+      ? Mongo.Collection.get(collectionName)
+      : global[collectionName];
+    return collection.findOne({
       _id: Template.instance().fileId.get() || this.value
     });
   }
@@ -69,7 +75,11 @@ Template.afFileUpload.events({
   },
   'change [data-files-collection-upload]'(e, template) {
     if (e.currentTarget.files && e.currentTarget.files[0]) {
-      var upload = global[template.collectionName()].insert({
+      var collectionName = template.collectionName();
+      var collection = Mongo.Collection.get
+        ? Mongo.Collection.get(collectionName)
+        : global[template.collectionName()];
+      var upload = collection.insert({
         file: e.currentTarget.files[0],
         streams: 'dynamic',
         chunkSize: 'dynamic'

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '2.0.1',
+  version: '2.0.2',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 
@@ -13,6 +13,7 @@ Package.onUse(function(api) {
     'check',
     'ecmascript',
     'underscore',
+    'mongo',
     'reactive-var',
     'templating',
     'aldeed:autoform@6.2.0',


### PR DESCRIPTION
I don't intend to use global namespace, since all my collections are encapsulated and referenced via dburles:mongo-collection-instances.

However, I also do not like workarounds in onRendered template functions. This approach assumes the **convention** of linking your FilesCollection to it's underlying collection instance.

Example:

Link the FilesCollection instance to the Mongo.Collection instance:

```javascript
export const Images = FilesCollection({  collectionName: 'Images' });
Images.collection.filesCollection = Images;
```

Retrieve the FilesCollection as every other collection instance:

```javascript
const Images = Mongo.Collection.get("images").filesCollection;
```

The change does **not add a dependency** to dburles:mongo-collection-instances but only checks if it's functionality (Mongo.Collection.get) exists. If not it falls back to the old mechanism.