### PR TITLE
Workaround for "Exception in template helper: idStringify after update to newest core package versions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Schemas.Posts = new SimpleSchema({
       afFieldInput: {
         type: 'fileUpload',
         collection: 'Images',
-        uploadTemplate: 'uploadField' // <- Optional
+        uploadTemplate: 'uploadField', // <- Optional
         previewTemplate: 'uploadPreview' // <- Optional
       }
     }
@@ -83,9 +83,9 @@ Generate the form with `{{> quickform}}` or `{{#autoform}}` e.g.:
 ##### Insert mode:
 
 ```html
-{{> quickForm collection="Posts" type="insert"}}
+{{> quickForm id="postsInsertForm" collection="Posts" type="insert"}}
 <!-- OR -->
-{{#autoForm collection="Posts" type="insert"}}
+{{#autoForm id="postsInsertForm" collection="Posts" type="insert"}}
   {{> afQuickField name="title"}}
   {{> afQuickField name="picture"}}
   <button type="submit" class="btn btn-primary">Insert</button>
@@ -96,11 +96,11 @@ Generate the form with `{{> quickform}}` or `{{#autoform}}` e.g.:
 
 ```html
 {{#if Template.subscriptionsReady }}
-  {{> quickForm collection="Posts" type="update" doc=getPost}}
+  {{> quickForm id="postsUpdateForm" collection="Posts" type="update" doc=getPost}}
 {{/if}}
 <!-- OR -->
 {{#if Template.subscriptionsReady }}
-  {{#autoForm collection="Posts" type="update" doc=getPost}}
+  {{#autoForm id="postsUpdateForm" collection="Posts" type="update" doc=getPost}}
     {{> afQuickField name="title"}}
     {{> afQuickField name="picture"}}
     <button type="submit" class="btn btn-primary">Update</button>

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -51,9 +51,11 @@ Template.afFileUpload.helpers({
     var collection = Mongo.Collection.get
       ? Mongo.Collection.get(collectionName).filesCollection
       : global[collectionName];
-    return collection.findOne({
-      _id: Template.instance().fileId.get() || this.value
-    });
+    if (!collectionName || !collection) return null;
+
+    var _id = Template.instance().fileId.get() || this.value;
+    if (typeof _id !== 'string' || _id.length === 0) return null;
+    return collection.findOne({_id:_id});
   }
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '2.0.2',
+  version: '2.0.3',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
     'reactive-var',
     'templating',
     'aldeed:autoform@6.2.0',
-    'ostrio:files@1.8.1'
+    'ostrio:files@1.8.2'
   ]);
 
   api.addFiles([


### PR DESCRIPTION
As described in #32 there is a problem with id values for findOne in newest minimongo.

Please check, if can even reproduce the error. If you can't reproduce, then this PR is not of use.

I couldn't track back, whether the error is caused by ostrio:files' findOne implementation or minimongo's internals.

However, when not using _id values, such as false or "" then there is no error thrown and the behavior is restored.
