### PR TITLE
Fix: VeliovGroup/Meteor-Files#263 and partial fixes #5

### DIFF
--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -101,7 +101,7 @@ Template.afFileUpload.events({
       const upload = template.collection.insert(opts, false);
       let ctx;
       try {
-        ctx    = AutoForm.getValidationContext(template.formId)
+        ctx = AutoForm.getValidationContext(template.formId);
       } catch {
         // Fix: "TypeError: Cannot read property '_resolvedSchema' of undefined"
         ctx = AutoForm.getValidationContext();

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -99,7 +99,13 @@ Template.afFileUpload.events({
       });
 
       const upload = template.collection.insert(opts, false);
-      const ctx    = AutoForm.getValidationContext(template.formId);
+      let ctx;
+      try {
+        ctx    = AutoForm.getValidationContext(template.formId)
+      } catch {
+        // Fix: "TypeError: Cannot read property '_resolvedSchema' of undefined"
+        ctx = AutoForm.getValidationContext();
+      }
 
       upload.on('start', function () {
         ctx.reset();

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -102,7 +102,7 @@ Template.afFileUpload.events({
       let ctx;
       try {
         ctx = AutoForm.getValidationContext(template.formId);
-      } catch {
+      } catch (e) {
         // Fix: "TypeError: Cannot read property '_resolvedSchema' of undefined"
         ctx = AutoForm.getValidationContext();
       }


### PR DESCRIPTION
Hello, @dr-dimitru.

I fixed the bug when `AutoForm.getValidationContext()` didn't recognize the `template.formId` and user got an error in console:

```
TypeError: Cannot read property '_resolvedSchema' of undefined
```

* fix: VeliovGroup/Meteor-Files#263;
* partial fix: #5.

Best wishes,
Sergey.