### PR TITLE
Prevent TypeError on mispelled collections

### DIFF
--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -22,9 +22,14 @@ Template.afFileUpload.onCreated(function () {
     };
   }
 
-  this.collection      = Mongo.Collection.get
-    ? Mongo.Collection.get(this.data.atts.collection).filesCollection
-    : (global[this.data.atts.collection] || Meteor.connection._mongo_livedata_collections[this.data.atts.collection].filesCollection);
+  const mongoCollection = Mongo.Collection.get
+    ? Mongo.Collection.get(this.data.atts.collection)
+    : Meteor.connection._mongo_livedata_collections[this.data.atts.collection]
+
+  this.collection = mongoCollection
+    ? mongoCollection.filesCollection
+    : global[this.data.atts.collection]
+
   this.uploadTemplate  = this.data.atts.uploadTemplate || null;
   this.previewTemplate = this.data.atts.previewTemplate || null;
   this.insertConfig    = Object.assign({}, this.data.atts.insertConfig || {});

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '2.1.1',
+  version: '2.1.2',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 


### PR DESCRIPTION
Related to #43 

The code is now first attempting to retrieve the underlying `Mongo.Collection` without directly accessing the `filesCollection` reference:

```javascript
const mongoCollection = Mongo.Collection.get
  ? Mongo.Collection.get(this.data.atts.collection)
  : Meteor.connection._mongo_livedata_collections[this.data.atts.collection]
```

If the `mongoCollection` is present the `filesCollection` reference will be assigned to `this.collection` otherwise a lookup in the `global` scope is performed.

```javascript
this.collection = mongoCollection
  ? mongoCollection.filesCollection
  : global[this.data.atts.collection]
```

In worst case `this.collection` is null, which will causes the already implemented 404 Error on line 46 to throw:

```javascript
if (!this.collection) {
  throw new Meteor.Error(404, '[meteor-autoform-files] No such collection "' + this.data.atts.collection + '"');
}
```

This should give developers a more accurate information on the issue than the previous `TypeError`