### PR TITLE
fix #37 by cleaning unintended insertConfig atts on hidden input

### DIFF
--- a/lib/client/fileUpload.html
+++ b/lib/client/fileUpload.html
@@ -1,5 +1,5 @@
 <template name="afFileUpload">
-  <input value="{{fileId}}" type="hidden" {{this.atts}}>
+  <input value="{{fileId}}" type="hidden" {{inputAtts this}}>
   {{#with uploadedFile}}
     {{#if previewTemplate}}
       {{>Template.dynamic template=previewTemplate}}

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -111,6 +111,12 @@ Template.afFileUpload.helpers({
   },
   accept() {
     return Template.instance().accept;
+  },
+  inputAtts(formContext) {
+    const { atts } = formContext;
+    if (!atts) return;
+    delete atts.insertConfig;
+    return atts;
   }
 });
 


### PR DESCRIPTION
The `insertConfig` is deleted in line 56:

```javascript
delete this.data.atts.insertConfig;
```

but there is the case that it is still present or "reassigned" by autoform (the reactivity makes properties reappear, I think) and this comes when the template re-renders but the onCreated has been only called once, so the insertConfig is not stripped again.

It is then later assigned to the input atts at 

```html
<input value="{{fileId}}" type="hidden" {{this.atts}}>
```

So I thought before messing with the whole reactivitity and break the whole package we just "clean" the atts using a helper when the template is drawn:

```html
<input value="{{fileId}}" type="hidden" {{inputAtts this}}>
```

```javascript
 inputAtts(formContext) {
    const { atts } = formContext;
    if (!atts) return;
    delete atts.insertConfig;
    return atts;
  }
```

Runs fine now on my side with any insert config. Can someone please confirm?

