### PR TITLE
Get form Id for validation context

### DIFF
--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -148,7 +148,7 @@ Template.afFileUpload.events({
       const upload = template.collection.insert(opts, false);
       let ctx;
       try {
-        ctx = AutoForm.getValidationContext(template.formId);
+        ctx = AutoForm.getValidationContext($(e.target).closest("form").attr('id'));
       } catch (exception) {
         // Fix: "TypeError: Cannot read property '_resolvedSchema' of undefined"
         ctx = AutoForm.getValidationContext();

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -70,7 +70,7 @@ Template.afFileUpload.onCreated(function () {
   this.currentUpload = new ReactiveVar(false);
   this.inputName     = this.data.name;
   this.fileId        = new ReactiveVar(this.data.value || false);
-  this.formId        = this.data.atts.id;
+  this.formId        = AutoForm.getFormId();
   return;
 });
 
@@ -148,7 +148,7 @@ Template.afFileUpload.events({
       const upload = template.collection.insert(opts, false);
       let ctx;
       try {
-        ctx = AutoForm.getValidationContext($(e.target).closest("form").attr('id'));
+        ctx = AutoForm.getValidationContext(template.formId);
       } catch (exception) {
         // Fix: "TypeError: Cannot read property '_resolvedSchema' of undefined"
         ctx = AutoForm.getValidationContext();


### PR DESCRIPTION
`template.formId` returns the file upload field id not the form id, but form id is a must for validation context to properly grab the form. 