### PR TITLE
📦 v2.3.0 (Meteor 1.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # Autoform File
 
 <a href="https://www.patreon.com/bePatron?u=20396046">
-  <img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" width="160">
+  <img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" height="38">
+</a>
+
+<a href="https://ostr.io/info/built-by-developers-for-developers">
+  <img src="https://ostr.io/apple-touch-icon-60x60.png" height="38">
 </a>
 
 ```shell
+# meteor@>=1.9
 meteor add ostrio:autoform-files
+
+# meteor@<1.9
+meteor add ostrio:autoform-files@2.2.1
 ```
 
 ## Description

--- a/lib/client/fileUpload.js
+++ b/lib/client/fileUpload.js
@@ -1,4 +1,3 @@
-import { _ }           from 'meteor/underscore';
 import { Meteor }      from 'meteor/meteor';
 import { AutoForm }    from 'meteor/aldeed:autoform';
 import { Template }    from 'meteor/templating';
@@ -52,15 +51,19 @@ Template.afFileUpload.onCreated(function () {
   this.uploadTemplate  = this.data.atts.uploadTemplate || null;
   this.previewTemplate = this.data.atts.previewTemplate || null;
   this.accept          = this.data.atts.accept || null;
-  this.insertConfig    = Object.assign({}, this.data.atts.insertConfig || {});
+  this.insertConfig    = Object.assign({}, defaultInsertOpts, this.data.atts.insertConfig || {});
   delete this.data.atts.insertConfig;
-  this.insertConfig    = Object.assign(this.insertConfig, _.pick(this.data.atts, Object.keys(defaultInsertOpts)));
 
-  if (!isNaN(this.insertConfig.streams) || this.insertConfig.streams !== 'dynamic') {
+  if (!isNaN(this.insertConfig.streams)) {
     this.insertConfig.streams = parseInt(this.insertConfig.streams);
+  } else if (this.insertConfig.streams !== 'dynamic') {
+    this.insertConfig.streams = 'dynamic';
   }
-  if (!isNaN(this.insertConfig.chunkSize) || this.insertConfig.chunkSize !== 'dynamic') {
+
+  if (!isNaN(this.insertConfig.chunkSize)) {
     this.insertConfig.chunkSize = parseInt(this.insertConfig.chunkSize);
+  } else if (this.insertConfig.chunkSize !== 'dynamic') {
+    this.insertConfig.chunkSize = 'dynamic';
   }
 
   this.collectionName = function () {

--- a/package.js
+++ b/package.js
@@ -2,22 +2,21 @@ Package.describe({
   name: 'ostrio:autoform-files',
   summary: 'File upload for AutoForm using ostrio:files',
   description: 'File upload for AutoForm using ostrio:files',
-  version: '2.2.1',
+  version: '2.3.0',
   git: 'https://github.com/VeliovGroup/meteor-autoform-file.git'
 });
 
 Package.onUse((api) => {
-  api.versionsFrom('METEOR@1.6.1');
+  api.versionsFrom('METEOR@1.9');
 
   api.use([
     'check',
     'ecmascript',
-    'underscore',
     'mongo',
     'reactive-var',
     'templating@1.3.2',
     'aldeed:autoform@6.3.0',
-    'ostrio:files@1.13.0'
+    'ostrio:files@1.14.0'
   ], 'client');
 
   api.addFiles([


### PR DESCRIPTION
- ☝️ This release focused on compatibility with `meteor@1.9.*` and `node@12.*.*`;
- 🤝 Compatibility with `meteor@1.9.*`;
- 🤝 Compatibility with `node@12.*.*`;
- 👨‍🔬 [Demo autoform-gridfs app](https://github.com/VeliovGroup/files-gridfs-autoform-example) is updated and tested agains latest meteor/node.js releases;

__Minor__:
- 🔥 Package version `v2.3.0` and newer is compatible __only__ with `meteor@1.9.*` and newer, due to changes in `meteor@1.9` and `node@12`

__Fixed__:
- 🐞 Fix issues from #57: *Default insertConfig chunksize and streams are NaN*, thanks to @jankapunkt;

__Updated__:
- 📦 __Remove__ `underscore` Atmosphere dependency for good;
- 📦 Update `ostrio:files` Atmosphere dependency to `v1.14.0`, *was `v1.13.0`*

//cc @jankapunkt